### PR TITLE
Return Expected JSON Response from Web Action

### DIFF
--- a/actions/changesWebAction.js
+++ b/actions/changesWebAction.js
@@ -79,7 +79,13 @@ function main(params) {
             .then(() => {
                  return createTrigger(db, triggerID, newTrigger);
             })
-            .then(resolve)
+            .then(() => {
+                 resolve({
+                     statusCode: 200,
+                     headers: {'Content-Type': 'application/json'},
+                     body: new Buffer(JSON.stringify({'status': 'success'})).toString('base64'),
+                 });
+            })
             .catch(err => {
                 reject(err);
             });
@@ -96,7 +102,13 @@ function main(params) {
             .then(() => {
                 return deleteTrigger(db, triggerID, 0);
             })
-            .then(resolve)
+            .then(() => {
+                resolve({
+                    statusCode: 200,
+                    headers: {'Content-Type': 'application/json'},
+                    body: new Buffer(JSON.stringify({'status': 'success'})).toString('base64'),
+                });
+            })
             .catch(err => {
                 reject(err);
             });


### PR DESCRIPTION
Invocation from changes.js sends an HTTP header with `Accept: application/json` to changesWebAction.js, so return JSON from the call instead of an empty payload that is not JSON.