### PR TITLE
Continue initialization if redundant provider is creating the filter

### DIFF
--- a/provider/app.js
+++ b/provider/app.js
@@ -51,7 +51,7 @@ function createDatabase(nanop) {
             if (!err) {
                 logger.info(method, 'created trigger database:', databaseName);
             }
-            else {
+            else if (err.statusCode !== 412) {
                 logger.info(method, 'failed to create trigger database:', databaseName, err);
             }
             var db = nanop.db.use(databaseName);
@@ -68,7 +68,7 @@ function createDatabase(nanop) {
                             only_triggers_by_worker: only_triggers_by_worker
                         },
                     }, ddname, function (error, body) {
-                        if (error) {
+                        if (error && error.statusCode !== 409) {
                             reject("filter could not be created: " + error);
                         }
                         resolve(db);

--- a/tests/src/test/scala/system/CloudantUtil.java
+++ b/tests/src/test/scala/system/CloudantUtil.java
@@ -251,7 +251,7 @@ public class CloudantUtil {
         docs.add("docs", bulkDocs);
         // use GET to get the document
         String dbname = credential.dbname;
-        Response response = given().port(443).baseUri(cloudantAccount(credential.user)).auth().basic(credential.user, credential.password).contentType("application/json").body(docs).post("/" + credential.dbname + "/_bulk_docs?include_docs=true");
+        Response response = given().port(443).baseUri(cloudantAccount(credential.user)).auth().basic(credential.user, credential.password).contentType("application/json").body(docs.toString()).post("/" + credential.dbname + "/_bulk_docs?include_docs=true");
         String responseStr = response.asString();
         if (responseStr.length() > 500)
             responseStr = responseStr.substring(0, 500);


### PR DESCRIPTION
A document update conflict (409) on filter creation is only possible if a redundant provider is currently creating the filter. Do not exit provider initialization in this situation. Also do not display message stating database creation failed if database already exists (412).