### PR TITLE
Switch to cloudant-nano (nano fork containing latest cloudant-follow)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "moment": "^2.11.1",
     "lodash": "^3.10.1",
     "request": "2.69.0",
-    "nano": "6.4.2",
+    "cloudant-nano": "6.7.0",
     "json-stringify-safe": "^5.0.1",
     "http-status-codes": "^1.0.5",
     "request-promise": "^1.0.2",

--- a/provider/app.js
+++ b/provider/app.js
@@ -47,7 +47,7 @@ function createDatabase() {
     var method = 'createDatabase';
     logger.info(method, 'creating the trigger database');
 
-    var nano = require('nano')(dbProtocol + '://' + dbUsername + ':' + dbPassword + '@' + dbHost);
+    var nano = require('cloudant-nano')(dbProtocol + '://' + dbUsername + ':' + dbPassword + '@' + dbHost);
 
     if (nano !== null) {
         return new Promise(function (resolve, reject) {

--- a/provider/lib/utils.js
+++ b/provider/lib/utils.js
@@ -40,7 +40,7 @@ module.exports = function(
         }
 
         try {
-            var nanoConnection = require('nano')(dbURL);
+            var nanoConnection = require('cloudant-nano')(dbURL);
             var triggeredDB = nanoConnection.use(dataTrigger.dbname);
 
             // Listen for changes on this database.


### PR DESCRIPTION
nano is using cloudant-follow version 0.13.0, which has a bug (cloudant-labs/cloudant-follow#14) causing the cloudant node.js app to randomly crash. Switching to use cloudant-nano, which is a fork of nano that is using version 0.15.0 of cloudant-follow (contains the fix).