### PR TITLE
add parameters as query parameters for get request

### DIFF
--- a/actions/changes.js
+++ b/actions/changes.js
@@ -42,7 +42,7 @@ function requestHelper(url, input, method) {
         } else {
             options.body = input;
         }
-        
+
         request(options, function(error, response, body) {
 
             if (!error && response.statusCode === 200) {

--- a/actions/changes.js
+++ b/actions/changes.js
@@ -30,12 +30,21 @@ function requestHelper(url, input, method) {
 
     return new Promise(function(resolve, reject) {
 
-        request({
+        var options = {
             method : method,
             url : url,
-            json: input,
             rejectUnauthorized: false
-        }, function(error, response, body) {
+        };
+
+        if (method === 'get') {
+            options.qs = input;
+            options.json = true;
+        } else {
+            options.json = true;
+            options.body = input;
+        }
+        
+        request(options, function(error, response, body) {
 
             if (!error && response.statusCode === 200) {
                 resolve(body);

--- a/actions/changes.js
+++ b/actions/changes.js
@@ -33,14 +33,13 @@ function requestHelper(url, input, method) {
         var options = {
             method : method,
             url : url,
+            json: true,
             rejectUnauthorized: false
         };
 
         if (method === 'get') {
             options.qs = input;
-            options.json = true;
         } else {
-            options.json = true;
             options.body = input;
         }
         


### PR DESCRIPTION
fix for `trigger get` failing in production because of executing a get request with a body