### PR TITLE
Test setup and teardown are being performed twice in some tests

### DIFF
--- a/tests/dat/filterdesigndoc.txt
+++ b/tests/dat/filterdesigndoc.txt
@@ -1,6 +1,7 @@
 {
   "_id": "_design/test_filter",
     "filters": {
-      "fruit": "function (doc, req) { return doc.kind === 'fruit' || (req && req.query && req.query.type === doc.type); }"
+      "fruit": "function (doc, req) { return doc.kind === 'fruit' || (req && req.query && req.query.type === doc.type); }",
+      "vegetable": "function (doc, req) { return doc.kind === 'vegetable' || (req && req.query && req.query.type === doc.type); }"
     }
 }

--- a/tests/src/test/scala/system/health/CloudantHealthFeedTests.scala
+++ b/tests/src/test/scala/system/health/CloudantHealthFeedTests.scala
@@ -52,7 +52,7 @@ class CloudantHealthFeedTests
 
     override def beforeEach() = {
         CloudantUtil.setUp(myCloudantCreds)
-        CloudantUtil.createDocument(myCloudantCreds, "{\"_id\":\"testid\"}")
+        CloudantUtil.createDocument(myCloudantCreds, "{\"_id\":\"testid\", \"kind\":\"vegetable\", \"type\":\"tomato\"}")
     }
 
     override def afterEach() = {
@@ -194,191 +194,189 @@ class CloudantHealthFeedTests
     }
 
     it should "return correct status and configuration" in withAssetCleaner(wskprops) {
-        val currentTime = s"${System.currentTimeMillis}"
-
         (wp, assetHelper) =>
             implicit val wskProps = wp
             val triggerName = s"dummyCloudantTrigger-${System.currentTimeMillis}"
             val packageName = "dummyCloudantPackage"
             val feed = "changes"
 
-            try {
-                CloudantUtil.setUp(myCloudantCreds)
+            // the package alarms should be there
+            val packageGetResult = wsk.pkg.get("/whisk.system/cloudant")
+            println("fetched package cloudant")
+            packageGetResult.stdout should include("ok")
 
-                // the package alarms should be there
-                val packageGetResult = wsk.pkg.get("/whisk.system/cloudant")
-                println("fetched package cloudant")
-                packageGetResult.stdout should include("ok")
-
-                // create package binding
-                assetHelper.withCleaner(wsk.pkg, packageName) {
-                    (pkg, name) => pkg.bind("/whisk.system/cloudant", name)
-                }
-
-                val username = myCloudantCreds.user
-                val password = myCloudantCreds.password
-                val host = myCloudantCreds.host()
-                val dbName = myCloudantCreds.dbname
-                val port = 443
-                val protocol = "https"
-                val since = "now"
-                val filter = "test_filter/fruit"
-                val queryParams = JsObject("type" -> JsString("tomato"))
-
-                // create whisk stuff
-                val feedCreationResult = assetHelper.withCleaner(wsk.trigger, triggerName, confirmDelete = false) {
-                    (trigger, name) =>
-                        trigger.create(name, feed = Some(s"$packageName/$feed"), parameters = Map(
-                            "username" -> username.toJson,
-                            "password" -> password.toJson,
-                            "host" -> host.toJson,
-                            "dbname" -> dbName.toJson,
-                            "filter" -> filter.toJson,
-                            "query_params" -> queryParams,
-                            "protocol" -> protocol.toJson,
-                            "port" -> port.toJson,
-                            "since" -> since.toJson
-                        ))
-                }
-                feedCreationResult.stdout should include("ok")
-
-                val actionName = s"$packageName/$feed"
-                val run = wsk.action.invoke(actionName, parameters = Map(
-                    "triggerName" -> triggerName.toJson,
-                    "lifecycleEvent" -> "READ".toJson,
-                    "authKey" -> wskProps.authKey.toJson
-                ))
-
-                withActivation(wsk.activation, run) {
-                    activation =>
-                        activation.response.success shouldBe true
-
-                        inside(activation.response.result) {
-                            case Some(result) =>
-                                val config = result.getFields("config").head.asInstanceOf[JsObject].fields
-                                val status = result.getFields("status").head.asInstanceOf[JsObject].fields
-
-                                config should contain("name" -> triggerName.toJson)
-                                config should contain("username" -> username.toJson)
-                                config should contain("password" -> password.toJson)
-                                config should contain("dbname" -> dbName.toJson)
-                                config should contain("filter" -> filter.toJson)
-                                config should contain("query_params" -> queryParams)
-                                config should contain("protocol" -> protocol.toJson)
-                                config should contain("port" -> port.toJson)
-                                config should contain("since" -> since.toJson)
-                                config should contain key "namespace"
-
-                                status should contain("active" -> true.toJson)
-                                status should contain key "dateChanged"
-                                status should contain key "dateChangedISO"
-                                status should not(contain key "reason")
-                        }
-                }
-            } finally {
-                CloudantUtil.unsetUp(myCloudantCreds)
+            // create package binding
+            assetHelper.withCleaner(wsk.pkg, packageName) {
+                (pkg, name) => pkg.bind("/whisk.system/cloudant", name)
             }
+
+            //Create filter design doc
+            val filterDesignDoc = CloudantUtil.createDesignFromFile(CloudantUtil.FILTER_DDOC_PATH).toString
+            val getResponse = CloudantUtil.createDocument(myCloudantCreds, filterDesignDoc)
+            getResponse.get("ok").getAsString shouldBe "true"
+
+            val username = myCloudantCreds.user
+            val password = myCloudantCreds.password
+            val host = myCloudantCreds.host()
+            val dbName = myCloudantCreds.dbname
+            val port = 443
+            val protocol = "https"
+            val since = "0"
+            val filter = "test_filter/fruit"
+            val queryParams = JsObject("type" -> JsString("tomato"))
+
+            // create whisk stuff
+            val feedCreationResult = assetHelper.withCleaner(wsk.trigger, triggerName, confirmDelete = false) {
+                (trigger, name) =>
+                    trigger.create(name, feed = Some(s"$packageName/$feed"), parameters = Map(
+                        "username" -> username.toJson,
+                        "password" -> password.toJson,
+                        "host" -> host.toJson,
+                        "dbname" -> dbName.toJson,
+                        "filter" -> filter.toJson,
+                        "query_params" -> queryParams,
+                        "protocol" -> protocol.toJson,
+                        "port" -> port.toJson,
+                        "since" -> since.toJson
+                    ))
+            }
+            feedCreationResult.stdout should include("ok")
+
+            val actionName = s"$packageName/$feed"
+            val run = wsk.action.invoke(actionName, parameters = Map(
+                "triggerName" -> triggerName.toJson,
+                "lifecycleEvent" -> "READ".toJson,
+                "authKey" -> wskProps.authKey.toJson
+            ))
+
+            withActivation(wsk.activation, run) {
+                activation =>
+                    activation.response.success shouldBe true
+
+                    inside(activation.response.result) {
+                        case Some(result) =>
+                            val config = result.getFields("config").head.asInstanceOf[JsObject].fields
+                            val status = result.getFields("status").head.asInstanceOf[JsObject].fields
+
+                            config should contain("name" -> triggerName.toJson)
+                            config should contain("username" -> username.toJson)
+                            config should contain("password" -> password.toJson)
+                            config should contain("dbname" -> dbName.toJson)
+                            config should contain("filter" -> filter.toJson)
+                            config should contain("query_params" -> queryParams)
+                            config should contain("protocol" -> protocol.toJson)
+                            config should contain("port" -> port.toJson)
+                            config should contain("since" -> since.toJson)
+                            config should contain key "namespace"
+
+                            status should contain("active" -> true.toJson)
+                            status should contain key "dateChanged"
+                            status should contain key "dateChangedISO"
+                            status should not(contain key "reason")
+                    }
+            }
+
+
     }
 
     it should "update filter and query_params parameters" in withAssetCleaner(wskprops) {
-        val currentTime = s"${System.currentTimeMillis}"
-
         (wp, assetHelper) =>
             implicit val wskProps = wp
             val triggerName = s"dummyCloudantTrigger-${System.currentTimeMillis}"
             val packageName = "dummyCloudantPackage"
             val feed = "changes"
 
-            try {
-                CloudantUtil.setUp(myCloudantCreds)
+            // the package alarms should be there
+            val packageGetResult = wsk.pkg.get("/whisk.system/cloudant")
+            println("fetched package cloudant")
+            packageGetResult.stdout should include("ok")
 
-                // the package alarms should be there
-                val packageGetResult = wsk.pkg.get("/whisk.system/cloudant")
-                println("fetched package cloudant")
-                packageGetResult.stdout should include("ok")
-
-                // create package binding
-                assetHelper.withCleaner(wsk.pkg, packageName) {
-                    (pkg, name) => pkg.bind("/whisk.system/cloudant", name)
-                }
-
-                val username = myCloudantCreds.user
-                val password = myCloudantCreds.password
-                val host = myCloudantCreds.host()
-                val dbName = myCloudantCreds.dbname
-                val filter = "test_filter/fruit"
-                val queryParams = JsObject("type" -> JsString("tomato"))
-
-                // create whisk stuff
-                val feedCreationResult = assetHelper.withCleaner(wsk.trigger, triggerName, confirmDelete = false) {
-                    (trigger, name) =>
-                        trigger.create(name, feed = Some(s"$packageName/$feed"), parameters = Map(
-                            "username" -> username.toJson,
-                            "password" -> password.toJson,
-                            "host" -> host.toJson,
-                            "dbname" -> dbName.toJson,
-                            "filter" -> filter.toJson,
-                            "query_params" -> queryParams
-                        ))
-                }
-                feedCreationResult.stdout should include("ok")
-
-                val actionName = s"$packageName/$feed"
-                val readRunResult = wsk.action.invoke(actionName, parameters = Map(
-                    "triggerName" -> triggerName.toJson,
-                    "lifecycleEvent" -> "READ".toJson,
-                    "authKey" -> wskProps.authKey.toJson
-                ))
-
-                withActivation(wsk.activation, readRunResult) {
-                    activation =>
-                        activation.response.success shouldBe true
-
-                        inside(activation.response.result) {
-                            case Some(result) =>
-                                val config = result.getFields("config").head.asInstanceOf[JsObject].fields
-
-                                config should contain("filter" -> filter.toJson)
-                                config should contain("query_params" -> queryParams)
-                        }
-                }
-
-                val updatedFilter = "test_filter/vegetable"
-                val updatedQueryParams = JsObject("type" -> JsString("celery"))
-
-                val updateRunAction = wsk.action.invoke(actionName, parameters = Map(
-                    "triggerName" -> triggerName.toJson,
-                    "lifecycleEvent" -> "UPDATE".toJson,
-                    "authKey" -> wskProps.authKey.toJson,
-                    "filter" -> updatedFilter.toJson,
-                    "query_params" -> updatedQueryParams
-                ))
-
-                withActivation(wsk.activation, updateRunAction) {
-                    activation =>
-                        activation.response.success shouldBe true
-                }
-
-                val runResult = wsk.action.invoke(actionName, parameters = Map(
-                    "triggerName" -> triggerName.toJson,
-                    "lifecycleEvent" -> "READ".toJson,
-                    "authKey" -> wskProps.authKey.toJson
-                ))
-
-                withActivation(wsk.activation, runResult) {
-                    activation =>
-                        activation.response.success shouldBe true
-
-                        inside(activation.response.result) {
-                            case Some(result) =>
-                                val config = result.getFields("config").head.asInstanceOf[JsObject].fields
-
-                                config should contain("filter" -> updatedFilter.toJson)
-                                config should contain("query_params" -> updatedQueryParams)
-                        }
-                }
-            } finally {
-                CloudantUtil.unsetUp(myCloudantCreds)
+            // create package binding
+            assetHelper.withCleaner(wsk.pkg, packageName) {
+                (pkg, name) => pkg.bind("/whisk.system/cloudant", name)
             }
+
+            //Create filter design doc
+            val filterDesignDoc = CloudantUtil.createDesignFromFile(CloudantUtil.FILTER_DDOC_PATH).toString
+            val getResponse = CloudantUtil.createDocument(myCloudantCreds, filterDesignDoc)
+            getResponse.get("ok").getAsString shouldBe "true"
+
+            val username = myCloudantCreds.user
+            val password = myCloudantCreds.password
+            val host = myCloudantCreds.host()
+            val dbName = myCloudantCreds.dbname
+            val filter = "test_filter/fruit"
+            val queryParams = JsObject("type" -> JsString("tomato"))
+
+            // create whisk stuff
+            val feedCreationResult = assetHelper.withCleaner(wsk.trigger, triggerName, confirmDelete = false) {
+                (trigger, name) =>
+                    trigger.create(name, feed = Some(s"$packageName/$feed"), parameters = Map(
+                        "username" -> username.toJson,
+                        "password" -> password.toJson,
+                        "host" -> host.toJson,
+                        "dbname" -> dbName.toJson,
+                        "filter" -> filter.toJson,
+                        "query_params" -> queryParams,
+                        "since" -> "0".toJson
+                    ))
+            }
+            feedCreationResult.stdout should include("ok")
+
+            val actionName = s"$packageName/$feed"
+            val readRunResult = wsk.action.invoke(actionName, parameters = Map(
+                "triggerName" -> triggerName.toJson,
+                "lifecycleEvent" -> "READ".toJson,
+                "authKey" -> wskProps.authKey.toJson
+            ))
+
+            withActivation(wsk.activation, readRunResult) {
+                activation =>
+                    activation.response.success shouldBe true
+
+                    inside(activation.response.result) {
+                        case Some(result) =>
+                            val config = result.getFields("config").head.asInstanceOf[JsObject].fields
+
+                            config should contain("filter" -> filter.toJson)
+                            config should contain("query_params" -> queryParams)
+                    }
+            }
+
+            val updatedFilter = "test_filter/vegetable"
+            val updatedQueryParams = JsObject("type" -> JsString("celery"))
+
+            val updateRunAction = wsk.action.invoke(actionName, parameters = Map(
+                "triggerName" -> triggerName.toJson,
+                "lifecycleEvent" -> "UPDATE".toJson,
+                "authKey" -> wskProps.authKey.toJson,
+                "filter" -> updatedFilter.toJson,
+                "query_params" -> updatedQueryParams
+            ))
+
+            withActivation(wsk.activation, updateRunAction) {
+                activation =>
+                    activation.response.success shouldBe true
+            }
+
+            val runResult = wsk.action.invoke(actionName, parameters = Map(
+                "triggerName" -> triggerName.toJson,
+                "lifecycleEvent" -> "READ".toJson,
+                "authKey" -> wskProps.authKey.toJson
+            ))
+
+            withActivation(wsk.activation, runResult) {
+                activation =>
+                    activation.response.success shouldBe true
+
+                    inside(activation.response.result) {
+                        case Some(result) =>
+                            val config = result.getFields("config").head.asInstanceOf[JsObject].fields
+
+                            config should contain("filter" -> updatedFilter.toJson)
+                            config should contain("query_params" -> updatedQueryParams)
+                    }
+            }
+
     }
 }

--- a/tests/src/test/scala/system/packages/CloudantFeedWebTests.scala
+++ b/tests/src/test/scala/system/packages/CloudantFeedWebTests.scala
@@ -55,37 +55,37 @@ class CloudantFeedWebTests
         wsk.action.get(webAction, FORBIDDEN)
     }
 
-    it should "reject put of a trigger due to missing triggerName argument" in {
+    it should "reject post of a trigger due to missing triggerName argument" in {
         val params = JsObject(requiredParams.fields - "triggerName")
 
         makePostCallWithExpectedResult(params, JsObject("error" -> JsString("no trigger name parameter was provided")), 400)
     }
 
-    it should "reject put of a trigger due to missing host argument" in {
+    it should "reject post of a trigger due to missing host argument" in {
         val params = JsObject(requiredParams.fields - "host")
 
         makePostCallWithExpectedResult(params, JsObject("error" -> JsString("cloudant trigger feed: missing host parameter")), 400)
     }
 
-    it should "reject put of a trigger due to missing username argument" in {
+    it should "reject post of a trigger due to missing username argument" in {
         val params = JsObject(requiredParams.fields - "username")
 
         makePostCallWithExpectedResult(params, JsObject("error" -> JsString("cloudant trigger feed: missing username parameter")), 400)
     }
 
-    it should "reject put of a trigger due to missing password argument" in {
+    it should "reject post of a trigger due to missing password argument" in {
         val params = JsObject(requiredParams.fields - "password")
 
         makePostCallWithExpectedResult(params, JsObject("error" -> JsString("cloudant trigger feed: missing password parameter")), 400)
     }
 
-    it should "reject put of a trigger due to missing dbname argument" in {
+    it should "reject post of a trigger due to missing dbname argument" in {
         val params = JsObject(requiredParams.fields - "dbname")
 
         makePostCallWithExpectedResult(params, JsObject("error" -> JsString("cloudant trigger feed: missing dbname parameter")), 400)
     }
 
-    it should "reject put of a trigger when authentication fails" in {
+    it should "reject post of a trigger when authentication fails" in {
 
         makePostCallWithExpectedResult(requiredParams, JsObject("error" -> JsString("Trigger authentication request failed.")), 401)
     }


### PR DESCRIPTION
The recently added health tests for trigger READ and UPDATE lifecycleEvents should not be calling setUp() and unsetUp() since these are already being called from the beforeEach() and afterEach() overrides.