### PR TITLE
update request package to a version without known memory leaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "winston": "^2.1.1",
     "moment": "^2.11.1",
     "lodash": "^3.10.1",
-    "request": "2.69.0",
+    "request": "^2.83.1",
     "cloudant-nano": "6.7.0",
     "json-stringify-safe": "^5.0.1",
     "http-status-codes": "^1.0.5",


### PR DESCRIPTION
The defined request package in version 2.69 does leak memory. The problem got fixed in 2.73.
I changed `package.json` to require the latest version of the request package (2.83.1) and added a caret to follow later updates.