### PR TITLE
validate that query_params is valid JSON

### DIFF
--- a/actions/changesWebAction.js
+++ b/actions/changesWebAction.js
@@ -48,6 +48,9 @@ function main(params) {
                 catch (e) {
                     return sendError(400, 'The query_params parameter cannot be parsed. Ensure it is valid JSON.');
                 }
+                if (typeof query_params !== 'object') {
+                    return sendError(400, 'The query_params parameter is not valid JSON');
+                }
             }
         }
         else if (params.query_params) {
@@ -168,6 +171,9 @@ function main(params) {
                                 }
                                 catch (e) {
                                     reject(sendError(400, 'The query_params parameter cannot be parsed. Ensure it is valid JSON.'));
+                                }
+                                if (typeof updatedParams.query_params !== 'object') {
+                                    reject(sendError(400, 'The query_params parameter is not valid JSON'));
                                 }
                             }
                         } else {


### PR DESCRIPTION
If invalid JSON for query_params is passed to the cloudant-follow API it will throw an exception and crash the provider.

/cloudantTrigger/node_modules/cloudant-follow/lib/feed.js:234
      query_params[key] = self[key];
                        ^

TypeError: Cannot create property 'feed' on string 'tweet'
    at /cloudantTrigger/node_modules/cloudant-follow/lib/feed.js:234:25
    at Array.forEach (<anonymous>)
    at Feed.query_feed [as query] (/cloudantTrigger/node_modules/cloudant-follow/lib/feed.js:232:8)
    at Request.db_response [as _callback] (/cloudantTrigger/node_modules/cloudant-follow/lib/feed.js:216:17)
    at Request.self.callback (/cloudantTrigger/node_modules/request/request.js:186:22)
    at emitTwo (events.js:126:13)
    at Request.emit (events.js:214:7)
    at Request.<anonymous> (/cloudantTrigger/node_modules/request/request.js:1163:10)
    at emitOne (events.js:116:13)
    at Request.emit (events.js:211:7)
    at IncomingMessage.<anonymous> (/cloudantTrigger/node_modules/request/request.js:1085:12)
    at Object.onceWrapper (events.js:313:30)
    at emitNone (events.js:111:20)
    at IncomingMessage.emit (events.js:208:7)
    at endReadableNT (_stream_readable.js:1064:12)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)