### PR TITLE
Add support for IAM based Cloudant DB instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ actions/event-actions/*.zip
 actions/event-actions/package.json
 .idea
 *.iml
+package-lock.json
 
 # Eclipse
 bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,4 @@
-FROM ubuntu:14.04
-
-ENV DEBIAN_FRONTEND noninteractive
-
-# Initial update and some basics.
-# This odd double update seems necessary to get curl to download without 404 errors.
-RUN apt-get update --fix-missing && \
-  apt-get install -y wget && \
-  apt-get update && \
-  apt-get install -y curl && \
-  apt-get update && \
-  apt-get remove -y nodejs && \
-  curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
-  apt-get install -y nodejs
+FROM node:8.12.0
 
 # only package.json
 ADD package.json /
@@ -23,4 +10,4 @@ ADD provider/. /cloudantTrigger/
 EXPOSE 8080
 
 # Run the app
-CMD ["/bin/bash", "-c", "node /cloudantTrigger/app.js >> /logs/cloudantTrigger_logs.log 2>&1"]
+CMD ["/bin/bash", "-c", "node /cloudantTrigger/app.js"]

--- a/actions/event-actions/changesWeb_package.json
+++ b/actions/event-actions/changesWeb_package.json
@@ -1,5 +1,8 @@
 {
   "name": "changesWebAction",
   "version": "1.0.0",
-  "main": "changesWebAction.js"
+  "main": "changesWebAction.js",
+  "dependencies" : {
+    "@cloudant/cloudant": "3.0.0"
+  }
 }

--- a/actions/event-actions/lib/Database.js
+++ b/actions/event-actions/lib/Database.js
@@ -2,8 +2,8 @@ const common = require('./common');
 
 // constructor for DB object - a thin, promise-loving wrapper around nano
 module.exports = function(dbURL, dbName) {
-    var nano = require('nano')(dbURL);
-    this.db = nano.db.use(dbName);
+    var cloudant = require('@cloudant/cloudant')(dbURL);
+    this.db = cloudant.db.use(dbName);
     var utilsDB = this;
 
     this.getWorkerID = function(availabeWorkers) {

--- a/installCatalog.sh
+++ b/installCatalog.sh
@@ -51,12 +51,8 @@ echo Installing Cloudant package.
 
 $WSK_CLI -i --apihost "$EDGEHOST" package update --auth "$AUTH" --shared yes cloudant \
     -a description "Cloudant database service" \
-    -a parameters '[ {"name":"bluemixServiceName", "required":false, "bindTime":true}, {"name":"username", "required":true, "bindTime":true, "description": "Your Cloudant username"}, {"name":"password", "required":true, "type":"password", "bindTime":true, "description": "Your Cloudant password"}, {"name":"host", "required":true, "bindTime":true, "description": "This is usually your username.cloudant.com"}, {"name":"dbname", "required":false, "description": "The name of your Cloudant database"}, {"name":"overwrite", "required":false, "type": "boolean"} ]' \
+    -a parameters '[  {"name":"bluemixServiceName", "required":false, "bindTime":true}, {"name":"username", "required":false, "bindTime":true, "description": "Your Cloudant username"}, {"name":"password", "required":false, "type":"password", "bindTime":true, "description": "Your Cloudant password"}, {"name":"host", "required":true, "bindTime":true, "description": "This is usually your username.cloudant.com"}, {"name":"iamApiKey", "required":false}, {"name":"iamUrl", "required":false}, {"name":"dbname", "required":false, "description": "The name of your Cloudant database"}, {"name":"overwrite", "required":false, "type": "boolean"} ]' \
     -p bluemixServiceName 'cloudantNoSQLDB' \
-    -p host '' \
-    -p username '' \
-    -p password '' \
-    -p dbname '' \
     -p apihost "$APIHOST"
 
 # make changesFeed.zip
@@ -73,7 +69,7 @@ $WSK_CLI -i --apihost "$EDGEHOST" action update --kind "$ACTION_RUNTIME_VERSION"
     -t 90000 \
     -a feed true \
     -a description 'Database change feed' \
-    -a parameters '[ {"name":"dbname", "required":true, "updatable":false}, {"name": "filter", "required":false, "updatable":true, "type": "string", "description": "The name of your Cloudant database filter"}, {"name": "query_params", "required":false, "updatable":true, "description": "JSON Object containing query parameters that are passed to the filter"} ]' \
+    -a parameters '[ {"name":"dbname", "required":true, "updatable":false}, {"name":"iamApiKey", "required":false, "updatable":false}, {"name":"iamUrl", "required":false, "updatable":false}, {"name": "filter", "required":false, "updatable":true, "type": "string", "description": "The name of your Cloudant database filter"}, {"name": "query_params", "required":false, "updatable":true, "description": "JSON Object containing query parameters that are passed to the filter"} ]' \
     -a sampleInput '{ "dbname": "mydb", "filter": "mailbox/by_status", "query_params": {"status": "new"} }'
 
 COMMAND=" -i --apihost $EDGEHOST package update --auth $AUTH --shared no cloudantWeb \
@@ -89,12 +85,13 @@ $WSK_CLI $COMMAND
 
 # make changesWebAction.zip
 cp -f changesWeb_package.json package.json
+npm install
 
 if [ -e changesWebAction.zip ]; then
     rm -rf changesWebAction.zip
 fi
 
-zip -r changesWebAction.zip lib package.json changesWebAction.js
+zip -r changesWebAction.zip lib package.json changesWebAction.js node_modules
 
 $WSK_CLI -i --apihost "$EDGEHOST" action update --kind "$ACTION_RUNTIME_VERSION" --auth "$AUTH" cloudantWeb/changesWebAction "$PACKAGE_HOME/actions/event-actions/changesWebAction.zip" \
     -a description 'Create/Delete a trigger in cloudant provider Database' \

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     "moment": "^2.11.1",
     "lodash": "^3.10.1",
     "request": "^2.83.0",
-    "cloudant-nano": "6.7.0",
+    "@cloudant/cloudant": "3.0.0",
     "json-stringify-safe": "^5.0.1",
     "http-status-codes": "^1.0.5",
     "request-promise": "^1.0.2",
-    "redis":"^2.7.1",
+    "redis": "^2.7.1",
     "bluebird": "^3.5.0",
     "systeminformation": "^3.19.0"
   }

--- a/provider/app.js
+++ b/provider/app.js
@@ -49,11 +49,11 @@ function createDatabase() {
     var method = 'createDatabase';
     logger.info(method, 'creating the trigger database');
 
-    var nano = require('cloudant-nano')(dbProtocol + '://' + dbUsername + ':' + dbPassword + '@' + dbHost);
+    var cloudant = require('@cloudant/cloudant')(dbProtocol + '://' + dbUsername + ':' + dbPassword + '@' + dbHost);
 
-    if (nano !== null) {
+    if (cloudant !== null) {
         return new Promise(function (resolve, reject) {
-            nano.db.create(databaseName, function (err, body) {
+            cloudant.db.create(databaseName, function (err, body) {
                 if (!err) {
                     logger.info(method, 'created trigger database:', databaseName);
                 }
@@ -74,7 +74,7 @@ function createDatabase() {
                     }
                 };
 
-                createDesignDoc(nano.db.use(databaseName), viewDDName, viewDD)
+                createDesignDoc(cloudant.db.use(databaseName), viewDDName, viewDD)
                 .then(db => {
                     var filterDD = {
                         filters: {
@@ -114,7 +114,7 @@ function createDatabase() {
         });
     }
     else {
-        Promise.reject('nano provider did not get created.  check db URL: ' + dbHost);
+        Promise.reject('cloudant provider did not get created.  check db URL: ' + dbHost);
     }
 }
 
@@ -181,7 +181,7 @@ function createRedisClient() {
 // Initialize the Provider Server
 function init(server) {
     var method = 'init';
-    var nanoDb;
+    var cloudantDb;
     var providerUtils;
 
     if (server !== null) {
@@ -194,11 +194,11 @@ function init(server) {
 
     createDatabase()
     .then(db => {
-        nanoDb = db;
+        cloudantDb = db;
         return createRedisClient();
     })
     .then(client => {
-        providerUtils = new ProviderUtils(logger, nanoDb, client);
+        providerUtils = new ProviderUtils(logger, cloudantDb, client);
         return providerUtils.initRedis();
     })
     .then(() => {

--- a/tests/src/test/scala/system/packages/CloudantFeedTests.scala
+++ b/tests/src/test/scala/system/packages/CloudantFeedTests.scala
@@ -132,7 +132,7 @@ class CloudantFeedTests
                         "host" -> myCloudantCreds.host().toJson),
                         expectedExitCode = 246)
             }
-            feedCreationResult.stderr should include("cloudant trigger feed: missing password parameter")
+            feedCreationResult.stderr should include("cloudant trigger feed: Must specify parameter/s of iamApiKey or username/password")
 
     }
 
@@ -163,7 +163,7 @@ class CloudantFeedTests
                         "host" -> myCloudantCreds.host().toJson),
                         expectedExitCode = 246)
             }
-            feedCreationResult.stderr should include("cloudant trigger feed: missing username parameter")
+            feedCreationResult.stderr should include("cloudant trigger feed: Must specify parameter/s of iamApiKey or username/password")
 
     }
 

--- a/tests/src/test/scala/system/packages/CloudantFeedWebTests.scala
+++ b/tests/src/test/scala/system/packages/CloudantFeedWebTests.scala
@@ -70,13 +70,13 @@ class CloudantFeedWebTests
     it should "reject post of a trigger due to missing username argument" in {
         val params = JsObject(requiredParams.fields - "username")
 
-        makePostCallWithExpectedResult(params, JsObject("error" -> JsString("cloudant trigger feed: missing username parameter")), 400)
+        makePostCallWithExpectedResult(params, JsObject("error" -> JsString("cloudant trigger feed: Must specify parameter/s of iamApiKey or username/password")), 400)
     }
 
     it should "reject post of a trigger due to missing password argument" in {
         val params = JsObject(requiredParams.fields - "password")
 
-        makePostCallWithExpectedResult(params, JsObject("error" -> JsString("cloudant trigger feed: missing password parameter")), 400)
+        makePostCallWithExpectedResult(params, JsObject("error" -> JsString("cloudant trigger feed: Must specify parameter/s of iamApiKey or username/password")), 400)
     }
 
     it should "reject post of a trigger due to missing dbname argument" in {


### PR DESCRIPTION
With this PR users can now listen to changes on Cloudant accounts that are IAM only enabled (the recommended approach).  See https://console.bluemix.net/docs/services/Cloudant/guides/iam.html#ibm-cloud-identity-and-access-management for details.