### PR TITLE
use nano instead of @cloudant

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lodash": "^3.10.1",
     "request": "^2.83.0",
     "@cloudant/cloudant": "3.0.0",
+    "nano": "8.0.1",
     "json-stringify-safe": "^5.0.1",
     "http-status-codes": "^1.0.5",
     "request-promise": "^1.0.2",

--- a/provider/app.js
+++ b/provider/app.js
@@ -66,7 +66,7 @@ function createDatabase() {
     var method = 'createDatabase';
     logger.info(method, 'creating the trigger database');
 
-    var cloudant = require('@cloudant/cloudant')(dbProtocol + '://' + dbUsername + ':' + dbPassword + '@' + dbHost);
+    var cloudant = require('nano')(dbProtocol + '://' + dbUsername + ':' + dbPassword + '@' + dbHost);
 
     if (cloudant !== null) {
         return new Promise(function (resolve, reject) {

--- a/provider/lib/utils.js
+++ b/provider/lib/utils.js
@@ -62,7 +62,7 @@ module.exports = function(logger, triggerDB, redisClient) {
             if (triggerData.port) {
                 url += ':' + triggerData.port;
             }
-            cloudantConnection = Cloudant(url);
+            cloudantConnection = require('nano')(url);
         }
 
         try {


### PR DESCRIPTION
when using the follow api with the @cloudant npm module a "RangeError: Maximum call stack size exceeded" exception is thrown when the cloudant host is unreachable.  With nano it will properly retry.